### PR TITLE
fix 'war' genre ID bug by replacing with 'drama'

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -91,7 +91,7 @@ fetch("https://love-calculator.p.rapidapi.com/getPercentage?fname=" + name1 + "&
                     let genreId = 27;
                     getMovieTitles(genreId);
                 } else if (data.percentage >=26 && data.percentage < 51) {
-                    let genreId = 10752;
+                    let genreId = 18;
                     getMovieTitles(genreId);
                 } else if (data.percentage >=51 && data.percentage < 76) {
                     let genreId = 53;


### PR DESCRIPTION
What Branch Does:
Fixes #44 
Switched war genre ID with drama since war ID was causing bugs

How to Test:
Calculate love % between Tommy & Kimberly and movies should pop up